### PR TITLE
Respect same translations directory as source

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,11 +65,19 @@ module.exports = {
 			exclude: this.options.files.exclude
 		});
 
-		intlTree = new FilterLiterals(intlTree, { filters: this.options.filters });
+		intlTree = new FilterLiterals(intlTree, {
+			filters: this.options.filters
+		});
 
-		intlTree = new ReduceLiterals([intlTree], { modules, common: this.app.name });
+		intlTree = new ReduceLiterals([intlTree], {
+			modules,
+			common: this.app.name
+		});
 
-		intlTree = new SplitTranslations([tree, intlTree], { translationsDir: this.options.translationsDir });
+		intlTree = new SplitTranslations([tree, intlTree], {
+			translationsDir: this.options.translationsDir,
+			common: this.app.name
+		});
 
 		tree = new Funnel(tree, { exclude: [`${this.options.translationsDir}/**/*.json`] });
 

--- a/lib/split-translations.js
+++ b/lib/split-translations.js
@@ -85,6 +85,7 @@ module.exports = class SplitTranslations extends TrackingWriter {
 			annotation: 'ember-cli-intl-shake:split-translations',
 			literalsFile: 'intl-literals.json',
 			translationsDir: 'translations',
+			common: null,
 			persistentOutput: true
 		}, options);
 
@@ -100,6 +101,7 @@ module.exports = class SplitTranslations extends TrackingWriter {
 		this.isTranslation = options.cacheInclude[1];
 		this.literalsFile = options.literalsFile;
 		this.translationsDir = options.translationsDir;
+		this.common = options.common;
 		this.translations = {};
 	}
 
@@ -122,15 +124,55 @@ module.exports = class SplitTranslations extends TrackingWriter {
 		const translations = this.getTranslationsFiles();
 		const pairs = changes.reduce((acc, change) => {
 			if (change.match(this.isLiteral)) {
-				acc.push(...translations.map((translation) => [change, translation].join(':')));
+				const module = this.getModuleFromLiteral(change);
+				const moduleTranslations = this.getTranslationsByModule(translations, module);
+
+				acc.push(...moduleTranslations.map((translation) => [change, translation].join(':')));
 			} else {
-				acc.push(...literals.map((literal) => [literal, change].join(':')));
+				const module = this.getModuleFromTranslation(change);
+				const moduleLiterals = this.getLiteralsByModule(literals, module);
+
+				acc.push(...moduleLiterals.map((literal) => [literal, change].join(':')));
 			}
 
 			return acc;
 		}, []);
 
 		return arrayUnique(pairs).map((pair) => pair.split(':'));
+	}
+
+	getTranslationsByModule(translations, module) {
+		if (module === this.common) {
+			const regexp = new RegExp(`^${this.translationsDir}/.+\\.json$`);
+
+			return translations.filter((translation) => regexp.test(translation));
+		}
+
+		return translations.filter((translation) => translation.match(module));
+	}
+
+	getLiteralsByModule(literals, module) {
+		return literals.filter((literal) => literal.match(module));
+	}
+
+	// Examples:
+	//  - dummy/intl-literals.json
+	//  - @lazy/engine/intl-literals.json
+	getModuleFromLiteral(file) {
+		const regexp = new RegExp(`^(.+)/${this.literalsFile}$`);
+		const matches = regexp.exec(file);
+
+		return matches && matches[1];
+	}
+
+	// Examples:
+	//  - translations/en-gb.json
+	//  - engines-dist/@lazy/engine/translations/en-gb.json
+	getModuleFromTranslation(file) {
+		const regexp = /^engines-dist\/(.+)\/translations\/.+\.json$/;
+		const matches = regexp.exec(file);
+
+		return matches ? matches[1] : this.common;
 	}
 
 	async getFile(relativePath) {
@@ -179,7 +221,7 @@ module.exports = class SplitTranslations extends TrackingWriter {
 		const moduleKeys = intersection(translationKeys, literals);
 		const moduleTranslations = inflateObject(filterObject(translations, moduleKeys));
 		const moduleContent = JSON.stringify(moduleTranslations);
-		const filename = path.join(this.outputPath, 'translations', module, `${locale}.json`);
+		const filename = path.join(this.outputPath, translationsPath);
 
 		if (await shouldWriteFile(filename, moduleContent)) {
 			await writeFile(filename, moduleContent);

--- a/node-tests/index-test.js
+++ b/node-tests/index-test.js
@@ -74,7 +74,7 @@ describe('When addon is enabled', function() {
 
 	context('and translations are centralized on app', () => {
 		it('generates translations file for app', async() => {
-			const translationFile = outputFilePath('translations', 'dummy', 'en-gb.json');
+			const translationFile = outputFilePath('translations', 'en-gb.json');
 
 			await assertFileExists(translationFile);
 			await assertContains(translationFile, 'dummy.template', 'Template');
@@ -89,7 +89,7 @@ describe('When addon is enabled', function() {
 		});
 
 		it('generates translations file for addons', async() => {
-			const translationFile = outputFilePath('translations', 'dummy', 'en-gb.json');
+			const translationFile = outputFilePath('translations', 'en-gb.json');
 
 			await assertFileExists(translationFile);
 			await assertContains(translationFile, 'dummy-addon.template', 'Template');
@@ -99,7 +99,7 @@ describe('When addon is enabled', function() {
 		});
 
 		it('generates translations file for eager engines', async() => {
-			const translationFile = outputFilePath('translations', 'dummy', 'en-gb.json');
+			const translationFile = outputFilePath('translations', 'en-gb.json');
 
 			await assertFileExists(translationFile);
 			await assertContains(translationFile, 'eager-engine.template', 'Template');
@@ -109,7 +109,7 @@ describe('When addon is enabled', function() {
 		});
 
 		it('generates translations file for lazy engines', async() => {
-			const translationFile = outputFilePath('translations', '@lazy', 'engine', 'en-gb.json');
+			const translationFile = outputFilePath('engines-dist', '@lazy', 'engine', 'translations', 'en-gb.json');
 
 			await assertFileExists(translationFile);
 			await assertContains(translationFile, 'lazy-engine.template', 'Template');
@@ -122,7 +122,7 @@ describe('When addon is enabled', function() {
 
 	context('and translations are distributed on addons and engines', () => {
 		it('generates translations file for app', async() => {
-			const translationFile = outputFilePath('translations', 'dummy', 'en-us.json');
+			const translationFile = outputFilePath('translations', 'en-us.json');
 
 			await assertFileExists(translationFile);
 			await assertContains(translationFile, 'dummy.template', 'Template');
@@ -137,7 +137,7 @@ describe('When addon is enabled', function() {
 		});
 
 		it('generates translations file for addons', async() => {
-			const translationFile = outputFilePath('translations', 'dummy', 'en-us.json');
+			const translationFile = outputFilePath('translations', 'en-us.json');
 
 			await assertFileExists(translationFile);
 			await assertContains(translationFile, 'dummy-addon.template', 'Template');
@@ -147,7 +147,7 @@ describe('When addon is enabled', function() {
 		});
 
 		it('generates translations file for eager engines', async() => {
-			const translationFile = outputFilePath('translations', 'dummy', 'en-us.json');
+			const translationFile = outputFilePath('translations', 'en-us.json');
 
 			await assertFileExists(translationFile);
 			await assertContains(translationFile, 'eager-engine.template', 'Template');
@@ -157,7 +157,7 @@ describe('When addon is enabled', function() {
 		});
 
 		it('generates translations file for lazy engines', async() => {
-			const translationFile = outputFilePath('translations', '@lazy', 'engine', 'en-us.json');
+			const translationFile = outputFilePath('engines-dist', '@lazy', 'engine', 'translations', 'en-us.json');
 
 			await assertFileExists(translationFile);
 			await assertContains(translationFile, 'lazy-engine.template', 'Template');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1626,7 +1626,8 @@
       "dev": true,
       "requires": {
         "ember-cli-babel": "*",
-        "ember-cli-htmlbars": "*"
+        "ember-cli-htmlbars": "*",
+        "ember-intl": "*"
       }
     },
     "@marionebl/sander": {

--- a/tests/dummy/lib/lazy-engine/package.json
+++ b/tests/dummy/lib/lazy-engine/package.json
@@ -6,6 +6,7 @@
   ],
   "dependencies": {
     "ember-cli-htmlbars": "*",
-    "ember-cli-babel": "*"
+    "ember-cli-babel": "*",
+    "ember-intl": "*"
   }
 }


### PR DESCRIPTION
Using ember-intl as engine dependency creates a translations clone inside engine-dist. Now we can use that file to prune unused literals inside engine.

BREAKING CHANGE: Destination files had been changed.